### PR TITLE
Added spacy component

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The `fastcoref` Python package provides an easy and fast API for coreference inf
 - [Installation](#Installation)
 - [Demo](#demo)
 - [Quick start](#quick-start)
+- [Spacy component](#spacy-component)
 - [Training](#distil-your-own-coref-model)
 - [Citation](#citation)
 
@@ -76,6 +77,24 @@ from fastcoref import LingMessCoref
 
 model = LingMessCoref(device='cuda:0')
 ```
+## Spacy component
+The package also provides a custom Spacy component that can be plugged into a Spacy(V3) pipeline. The custom component can be added to your pipeline using the name "fastcoref" after importing spacy_component. You can choose the model_architecture as either FCoref or LingMessCoref. If you'd like to use your own trained version you can specify the model_path parameter pointing to your model. The example below shows how to use the pre-trained FCoref model.
+```python
+from fastcoref import spacy_component
+texts = ['We are so happy to see you using our coref package. This package is very fast!',
+         'Glad to see you are using the spacy component as well. As it is a new feature!'
+        ]
+nlp = spacy.load("en_core_web_sm", exclude=["parser", "lemmatizer", "ner", "textcat"])
+nlp.add_pipe("fastcoref",config={'model_architecture':'FCoref',"model_path":'biu-nlp/f-coref','device':'cuda'})
+```
+After adding the model to your Spacy pipeline, the coreference clusters derived by the model can be accessed through the .\_.coref_clusters attribute of the outputted documents. It is also possible to access a version of the text with the coreferences already resolved through the .\_.resolved_text attribute. However this second attribute requires you to pass an optional resolved_text parameter as True to the component config when passing the documents through the pipeline. Important things to note are; Resolving the text requires the tagger component to be in the pipeline and is slower than just extracting the coreference clusters implementation-wise.
+```python
+
+doc_list = nlp.pipe(texts,component_cfg={"fastcoref":{'resolve_text':True}})
+for doc in doc_list:
+   print(doc._.resolved_text)
+   print(doc._.coref_clusters)
+```
 
 ## Distil your own coref model
 On top of the provided models, the package also provides the ability to train and distill coreference models on your own data, opening the possibility for fast and accurate coreference models for additional languages and domains.
@@ -139,8 +158,6 @@ model = LingMessCoref(
    device='cuda:0'
 )
 ```
-
-Or in case of LingMess model:
 
 
 ## Citation

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -175,7 +175,7 @@ class CorefModel(ABC):
 
                 progress_bar.update(n=len(texts))
 
-        return results
+        return sorted(results, key=lambda res: res.text_idx)
 
     def predict(self, texts, max_tokens_in_batch=10000):
         is_str = False

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -22,12 +22,13 @@ logging.basicConfig(format='%(asctime)s - %(levelname)s - \t %(message)s',
 
 
 class CorefResult:
-    def __init__(self, text, clusters, char_map, reverse_char_map, coref_logit):
+    def __init__(self, text, clusters, char_map, reverse_char_map, coref_logit, text_idx):
         self.text = text
         self.clusters = clusters
         self.char_map = char_map
         self.reverse_char_map = reverse_char_map
         self.coref_logit = coref_logit
+        self.text_idx = text_idx
 
     def get_clusters(self, as_strings=True):
         if not as_strings:
@@ -118,8 +119,8 @@ class CorefModel(ABC):
 
     def _create_dataset(self, texts):
         logger.info(f'Tokenize {len(texts)} texts...')
-
-        dataset = Dataset.from_dict({'text': texts})
+        # Save original text ordering for later use
+        dataset = Dataset.from_dict({'text': texts,'idx':range(len(texts))})
         dataset = dataset.map(
             encode, batched=True, batch_size=10000,
             fn_kwargs={'tokenizer': self.tokenizer, 'nlp': self.nlp}
@@ -148,7 +149,7 @@ class CorefModel(ABC):
                 texts = batch['text']
                 subtoken_map = batch['subtoken_map']
                 token_to_char = batch['offset_mapping']
-
+                idxs = batch['idx']
                 with torch.no_grad():
                     outputs = self.model(batch, return_all_outputs=True)
 
@@ -168,7 +169,7 @@ class CorefModel(ABC):
                     res = CorefResult(
                         text=texts[i], clusters=predicted_clusters,
                         char_map=char_map, reverse_char_map=reverse_char_map,
-                        coref_logit=coref_logits[i]
+                        coref_logit=coref_logits[i], text_idx = idxs[i]
                     )
                     results.append(res)
 

--- a/fastcoref/spacy_component/__init__.py
+++ b/fastcoref/spacy_component/__init__.py
@@ -1,0 +1,1 @@
+from .spacy_component import FastCorefResolver

--- a/fastcoref/spacy_component/spacy_component.py
+++ b/fastcoref/spacy_component/spacy_component.py
@@ -1,0 +1,150 @@
+
+from spacy import Language, util
+from spacy.tokens import Doc, Span
+from fastcoref import FCoref, LingMessCoref
+from typing import List,Tuple
+
+
+@Language.factory(
+    "fastcoref",
+    assigns=["doc._.resolved_text","doc._.coref_clusters"],
+    default_config={
+        "model_name": "FCoref",
+        "device": "cuda:0",
+        "max_tokens_in_batch":5000
+    },
+)
+class FastCorefResolver:
+    """a class that implements the logic from
+    https://towardsdatascience.com/how-to-make-an-effective-coreference-resolution-model-55875d2b5f19"""
+    def __init__(
+        self,
+        nlp,
+        name,
+        model_name: str,
+        device: str,
+        max_tokens_in_batch: int
+    ):
+        assert model_name in ["FCoref","LingMessCoref"]
+        if model_name == "FCoref": 
+            self.coref_model = FCoref(device=device)
+        elif model_name == "LingMessCoref":
+            self.coref_model = LingMessCoref(device=device)
+        self.max_tokens_in_batch = max_tokens_in_batch
+        # Register custom extension on the Doc
+        if not Doc.has_extension("resolved_text"):
+            Doc.set_extension("resolved_text", default="")
+        if not Doc.has_extension("coref_clusters"):
+            Doc.set_extension("coref_clusters", default=None)
+         
+    def _get_span_noun_indices(self, doc: Doc, cluster: List[Tuple]) -> List[int]:
+        """
+        > Get the indices of the spans in the cluster that contain at least one noun or proper noun
+        :param doc: Doc
+        :param cluster: List[Tuple]
+        :return: A list of indices of spans that contain at least one noun or proper noun.
+        """
+        spans = [doc.char_span(span[0],span[1]) for span in cluster]
+        spans_pos = [[token.pos_ for token in span] for span in spans]
+        span_noun_indices = [
+            i for i, span_pos in enumerate(spans_pos) if any(pos in span_pos for pos in ["NOUN", "PROPN"])
+        ]
+        return span_noun_indices
+    def _get_cluster_head(self, doc: Doc, cluster: List[Tuple], noun_indices: List[int]):
+        """
+        > Given a spaCy Doc, a coreference cluster, and a list of noun indices, return the head span and its start and end
+        indices
+        :param doc: the spaCy Doc object
+        :type doc: Doc
+        :param cluster: a list of Tuples, where each tuple is a char indices of token in the document
+        :type cluster: List[Tuple]
+        :param noun_indices: a list of indices of the nouns in the cluster
+        :type noun_indices: List[int]
+        :return: The head span and the start and end indices of the head span.
+        """
+        head_idx = noun_indices[0]
+        head_start,head_end = cluster[head_idx]
+        head_span = doc.char_span(head_start,head_end)
+        return head_span, [head_start, head_end]
+    def _is_containing_other_spans(self,span: List[int], all_spans: List[List[int]]):
+        """
+        It returns True if there is any span in all_spans that is contained within span and is not equal to span
+        :param span: the span we're checking to see if it contains other spans
+        :type span: List[int]
+        :param all_spans: a list of all the spans in the document
+        :type all_spans: List[List[int]]
+        :return: A list of all spans that are not contained in any other span.
+        """
+        return any([s[0] >= span[0] and s[1] <= span[1] and s != span for s in all_spans])
+    def _core_logic_part(self,document: Doc, coref: List[int], resolved: List[str], mention_span: Span):
+        """
+        If the last token of the mention is a possessive pronoun, then add an apostrophe and an s to the mention.
+        Otherwise, just add the last token to the mention
+        :param document: Doc object
+        :type document: Doc
+        :param coref: List[int]
+        :param resolved: list of strings, where each string is a token in the sentence
+        :param mention_span: The span of the mention that we want to replace
+        :return: The resolved list is being returned.
+        """
+        char_span = document.char_span(coref[0],coref[1])
+        final_token = char_span[-1]
+        final_token_tag = str(final_token.tag_).lower()
+        test_token_test = False
+        for option in ["PRP$", "POS", "BEZ"]:
+            if option.lower() in final_token_tag:
+                test_token_test = True
+                break
+        if test_token_test:
+            resolved[char_span.start] = mention_span.text + "'s" + final_token.whitespace_
+        else:
+            resolved[char_span.start] = mention_span.text + final_token.whitespace_
+        for i in range(char_span.start + 1, char_span.end):
+            resolved[i] = ""
+        return resolved
+    def __call__(self, doc: Doc) -> Doc:
+        """
+        The function takes a doc object and returns a doc object
+        :param doc: Doc
+        :type doc: Doc
+        :return: A Doc object with the resolved text and coreference clusters added as attributes.
+        """
+        preds = self.coref_model.predict(texts=[doc.text])
+        clusters = preds[0].get_clusters(as_strings=False)
+        resolved = list(tok.text_with_ws for tok in doc)
+        cluster_heads = {}
+        all_spans = [span for cluster in clusters for span in cluster]
+        for cluster in clusters:
+            indices = self._get_span_noun_indices(doc,cluster)
+            if indices:
+                mention_span, mention = self._get_cluster_head(doc, cluster, indices)
+                cluster_heads[str(mention_span)] = mention
+                for coref in cluster:
+                    if coref != mention and not self._is_containing_other_spans(coref, all_spans):
+                        self._core_logic_part(doc, coref, resolved, mention_span)
+        doc._.resolved_text = "".join(resolved)
+        doc._.coref_clusters = clusters
+        return doc
+    def pipe(self, stream, batch_size=512):
+        for docs in util.minibatch(stream, size=batch_size):
+            preds = self.coref_model.predict(
+                    texts=[doc.text for doc in docs],max_tokens_in_batch=self.max_tokens_in_batch)
+                    
+            for pred in preds:
+                clusters = pred.get_clusters(as_strings=False)
+                doc = docs[pred.text_idx] #Find document since preds returns random order
+                resolved = list(tok.text_with_ws for tok in doc)
+                cluster_heads = {}
+                all_spans = [span for cluster in clusters for span in cluster]
+                for cluster in clusters:
+                        indices = self._get_span_noun_indices(doc,cluster)
+                        if indices:
+                            mention_span, mention = self._get_cluster_head(doc, cluster, indices)
+                            cluster_heads[str(mention_span)] = mention
+
+                            for coref in cluster:
+                                if coref != mention and not self._is_containing_other_spans(coref, all_spans):
+                                    self._core_logic_part(doc, coref, resolved, mention_span)
+                doc._.resolved_text = "".join(resolved)
+                doc._.coref_clusters = clusters
+                yield doc

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup, find_packages
 
 import sys
+
+import fastcoref
 if sys.version_info < (3,7):
     sys.exit('Python < 3.7 is not supported')
 
@@ -17,7 +19,7 @@ setup(
     license='MIT',
     author="Shon Otmazgin, Arie Cattan, Yoav Goldberg",
     author_email='shon711@gmail.com',
-    packages=['fastcoref', 'fastcoref.coref_models', 'fastcoref.utilities'],
+    packages=['fastcoref', 'fastcoref.coref_models', 'fastcoref.utilities','fastcoref.spacy_component'],
     url='https://github.com/shon-otmazgin/fastcoref',
     install_requires=[
         'tqdm>=4.64.0',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup, find_packages
 
 import sys
 
-import fastcoref
 if sys.version_info < (3,7):
     sys.exit('Python < 3.7 is not supported')
 

--- a/tests/local_test.py
+++ b/tests/local_test.py
@@ -1,4 +1,4 @@
-from fastcoref import FCoref, LingMessCoref, CorefArgs
+from fastcoref import FCoref, LingMessCoref
 
 texts = ['We are so happy to see you using our coref package. This package is very fast!',
          'The man tried to put the boot on his foot but it was too small.',

--- a/tests/test_spacy_component.py
+++ b/tests/test_spacy_component.py
@@ -6,27 +6,27 @@ texts = ['We are so happy to see you using our coref package. This package is ve
          'Alice goes down the rabbit hole. Where she would discover a new reality beyond her expectations.'
         ]
 
-nlp_fcoref = spacy.load("en_core_web_sm", exclude=["parser", "lemmatizer", "ner", "textcat"]) #Resolving references requires pos tagging
-nlp_fcoref.add_pipe("fastcoref",config={'model_name':'FCoref','device':'cuda:0'})
-# Test __call__
+nlp_fcoref = spacy.load("en_core_web_sm", exclude=["parser", "lemmatizer", "ner", "textcat"]) #Resolving text requires pos tagging
+nlp_fcoref.add_pipe("fastcoref",config={'model_architecture':'FCoref',"model_path":'biu-nlp/f-coref','device':'cuda'})
+# Test __call__ while not returning resolved text
 doc = nlp_fcoref(texts[0])
 print(doc._.resolved_text)
 print(doc._.coref_clusters)
-# Test pipe
-doc_list = nlp_fcoref.pipe(texts)
+# Test pipe while returning resolved text
+doc_list = nlp_fcoref.pipe(texts,component_cfg={"fastcoref":{'resolve_text':True}})
 for doc in doc_list:
     print(doc._.resolved_text)
     print(doc._.coref_clusters)
 
 
-nlp_lingmess = spacy.load("en_core_web_sm", exclude=["parser", "lemmatizer", "ner", "textcat"])#Resolving references requires pos tagging
-nlp_lingmess.add_pipe("fastcoref",config={'model_name':'LingMessCoref','device':'cuda:0'})
-# Test __call__
-doc = nlp_lingmess(texts[0])
+nlp_lingmess = spacy.load("en_core_web_sm", exclude=["parser", "lemmatizer", "ner", "textcat"])#Resolving text requires pos tagging
+nlp_lingmess.add_pipe("fastcoref",config={'model_architecture':'LingMessCoref','model_path':'biu-nlp/lingmess-coref','device':'cuda'})
+# Test __call__ while returning resolved text
+doc = nlp_lingmess(texts[0],component_cfg={"fastcoref":{'resolve_text':True}})
 print(doc._.resolved_text)
 print(doc._.coref_clusters)
-# Test pipe
-doc_list = nlp_lingmess.pipe(texts)
+# Test pipe while not returning resolved text
+doc_list = nlp_lingmess.pipe(texts,component_cfg={"fastcoref":{'resolve_text':False}})
 for doc in doc_list:
     print(doc._.resolved_text)
     print(doc._.coref_clusters)

--- a/tests/test_spacy_component.py
+++ b/tests/test_spacy_component.py
@@ -1,0 +1,32 @@
+from fastcoref import spacy_component
+import spacy
+texts = ['We are so happy to see you using our coref package. This package is very fast!',
+         'Glad to see you are using the spacy component as well. As it is a new feature!',
+         'The man tried to put the boot on his foot but it was too small.',
+         'Alice goes down the rabbit hole. Where she would discover a new reality beyond her expectations.'
+        ]
+
+nlp_fcoref = spacy.load("en_core_web_sm", exclude=["parser", "lemmatizer", "ner", "textcat"]) #Resolving references requires pos tagging
+nlp_fcoref.add_pipe("fastcoref",config={'model_name':'FCoref','device':'cuda:0'})
+# Test __call__
+doc = nlp_fcoref(texts[0])
+print(doc._.resolved_text)
+print(doc._.coref_clusters)
+# Test pipe
+doc_list = nlp_fcoref.pipe(texts)
+for doc in doc_list:
+    print(doc._.resolved_text)
+    print(doc._.coref_clusters)
+
+
+nlp_lingmess = spacy.load("en_core_web_sm", exclude=["parser", "lemmatizer", "ner", "textcat"])#Resolving references requires pos tagging
+nlp_lingmess.add_pipe("fastcoref",config={'model_name':'LingMessCoref','device':'cuda:0'})
+# Test __call__
+doc = nlp_lingmess(texts[0])
+print(doc._.resolved_text)
+print(doc._.coref_clusters)
+# Test pipe
+doc_list = nlp_lingmess.pipe(texts)
+for doc in doc_list:
+    print(doc._.resolved_text)
+    print(doc._.coref_clusters)


### PR DESCRIPTION
- Added [spacy component](https://github.com/shon-otmazgin/fastcoref/issues/5) which works out of the box:
   - Can be added to any spacy pipeline as "fastcoref" after importing spacy_component
   - Resolves coreferences automatically and saves the resolved text into doc._.resolved_text
   - Saves the coreference clusters into doc._.coref_clusters
- CorefResult now supports accessing the original text orderings for any down stream tasks, through the text_idx attribute([related issue](https://github.com/shon-otmazgin/fastcoref/issues/4)). As this was also needed for the spacy component implementation.
- Added tests for the spacy component 