### PR TITLE
Pretokenized input

### DIFF
--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -73,8 +73,8 @@ class CorefResult:
             raise ValueError(f'span_token_i="{self.text[span_token_i[0]:span_token_i[1]]}" is not an entity in this model!')
         if span_token_j not in self.reverse_subtoken_map:
             raise ValueError(f'span_token_j="{self.text[span_token_j[0]:span_token_j[1]]}" is not an entity in this model!')
-        sorted_span = sorted([self.reverse_subtoken_map[span_token_i], self.reverse_subtoken_map[span_token_j]], reversed=True)
-        return self.coref_logit[sorted_span[0], sorted_span[1]]
+        sorted_span = sorted([self.reverse_subtoken_map[span_token_i], self.reverse_subtoken_map[span_token_j]])
+        return self.coref_logit[sorted_span[1], sorted_span[0]]
 
     def __str__(self):
         if len(self.text) > 50:

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -73,10 +73,8 @@ class CorefResult:
             raise ValueError(f'span_token_i="{self.text[span_token_i[0]:span_token_i[1]]}" is not an entity in this model!')
         if span_token_j not in self.reverse_subtoken_map:
             raise ValueError(f'span_token_j="{self.text[span_token_j[0]:span_token_j[1]]}" is not an entity in this model!')
-        return self.get_logit[
-            self.reverse_subtoken_map[span_token_i],
-            self.reverse_subtoken_map[span_token_j],
-        ]
+        span_larger_idx, span_smaller_idx = sorted(self.reverse_subtoken_map[span_token_i], self.reverse_subtoken_map[span_token_j], reversed=True)
+        return self.coref_logit[span_larger_idx, span_smaller_idx]
 
     def __str__(self):
         if len(self.text) > 50:

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -37,7 +37,8 @@ class CorefResult:
         if subtoken_map:
             self.reverse_subtoken_map = dict()
             for (stok_start, stok_end), (span_i, _) in char_map.items():
-                self.reverse_subtoken_map[(subtoken_map[stok_start], subtoken_map[stok_end])] = span_i
+                if stok_start is not None and stok_end is not None:
+                    self.reverse_subtoken_map[(subtoken_map[stok_start], subtoken_map[stok_end])] = span_i
 
     def get_clusters(self, as_strings=True):
         if not as_strings:

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -37,7 +37,7 @@ class CorefResult:
         if subtoken_map:
             self.reverse_subtoken_map = dict()
             for (stok_start, stok_end), (span_i, _) in char_map.items():
-                if stok_start is not None and stok_end is not None:
+                if subtoken_map[stok_start] is not None and subtoken_map[stok_end] is not None:
                     self.reverse_subtoken_map[(subtoken_map[stok_start], subtoken_map[stok_end])] = span_i
 
     def get_clusters(self, as_strings=True):

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -36,7 +36,7 @@ class CorefResult:
         self.reverse_subtoken_map = None
         if subtoken_map:
             self.reverse_subtoken_map = dict()
-            for (stok_start, stok_end), (span_i, _) in reverse_char_map.items():
+            for (stok_start, stok_end), (span_i, _) in char_map.items():
                 self.reverse_subtoken_map[(subtoken_map[stok_start], subtoken_map[stok_end])] = span_i
 
     def get_clusters(self, as_strings=True):

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -73,8 +73,8 @@ class CorefResult:
             raise ValueError(f'span_token_i="{self.text[span_token_i[0]:span_token_i[1]]}" is not an entity in this model!')
         if span_token_j not in self.reverse_subtoken_map:
             raise ValueError(f'span_token_j="{self.text[span_token_j[0]:span_token_j[1]]}" is not an entity in this model!')
-        span_larger_idx, span_smaller_idx = sorted(self.reverse_subtoken_map[span_token_i], self.reverse_subtoken_map[span_token_j], reversed=True)
-        return self.coref_logit[span_larger_idx, span_smaller_idx]
+        sorted_span = sorted([self.reverse_subtoken_map[span_token_i], self.reverse_subtoken_map[span_token_j]], reversed=True)
+        return self.coref_logit[sorted_span[0], sorted_span[1]]
 
     def __str__(self):
         if len(self.text) > 50:

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -147,7 +147,7 @@ class CorefModel(ABC):
     def _create_dataset(self, texts, tokenized_texts=None):
         logger.info(f'Tokenize {len(texts)} texts...')
         # Save original text ordering for later use
-        dataset = Dataset.from_dict({'text': texts, 'tokenized_text': [] if not tokenized_texts else tokenized_texts, 'idx':range(len(texts))})
+        dataset = Dataset.from_dict({'text': texts, 'tokenized_text': [None for _ in range(len(texts))] if not tokenized_texts else tokenized_texts, 'idx':range(len(texts))})
         dataset = dataset.map(
             encode, batched=True, batch_size=10000,
             fn_kwargs={'tokenizer': self.tokenizer, 'nlp': self.nlp}

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -37,7 +37,7 @@ class CorefResult:
         if subtoken_map:
             self.reverse_subtoken_map = dict()
             for (stok_start, stok_end), (span_i, _) in char_map.items():
-                if subtoken_map[stok_start] is not None and subtoken_map[stok_end] is not None:
+                if span_i is not None:
                     self.reverse_subtoken_map[(subtoken_map[stok_start], subtoken_map[stok_end])] = span_i
 
     def get_clusters(self, as_strings=True):

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -147,7 +147,7 @@ class CorefModel(ABC):
     def _create_dataset(self, texts, tokenized_texts=None):
         logger.info(f'Tokenize {len(texts)} texts...')
         # Save original text ordering for later use
-        dataset = Dataset.from_dict({'text': texts, 'tokenized_text': tokenized_texts, 'idx':range(len(texts))})
+        dataset = Dataset.from_dict({'text': texts, 'tokenized_text': [] if not tokenized_texts else tokenized_texts, 'idx':range(len(texts))})
         dataset = dataset.map(
             encode, batched=True, batch_size=10000,
             fn_kwargs={'tokenizer': self.tokenizer, 'nlp': self.nlp}

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -182,9 +182,13 @@ class CorefModel(ABC):
                     )
 
                     res = CorefResult(
-                        text=texts[i], clusters=predicted_clusters,
-                        char_map=char_map, reverse_char_map=reverse_char_map,
-                        coref_logit=coref_logits[i], text_idx=idxs[i], tokenized_text=tokenized_texts[i]
+                        text=texts[i],
+                        clusters=predicted_clusters,
+                        char_map=char_map,
+                        reverse_char_map=reverse_char_map,
+                        coref_logit=coref_logits[i],
+                        text_idx=idxs[i],
+                        tokenized_text=tokenized_texts[i] if tokenized_texts else None,
                     )
                     results.append(res)
 

--- a/fastcoref/utilities/util.py
+++ b/fastcoref/utilities/util.py
@@ -84,7 +84,10 @@ def update_metrics(metrics, span_starts, span_ends, gold_clusters, predicted_clu
 
 
 def encode(batch, tokenizer, nlp):
-    tokenized_texts = tokenize_with_spacy(batch['text'], nlp)
+    if batch['tokenized_text']:
+        tokenized_texts = preprocess_tokenized_texts(batch['tokenized_text'])
+    else:
+        tokenized_texts = tokenize_with_spacy(batch['text'], nlp)
     encoded_batch = tokenizer(
         tokenized_texts['tokens'], add_special_tokens=True, is_split_into_words=True,
         return_length=True, return_attention_mask=False
@@ -101,6 +104,17 @@ def encode(batch, tokenizer, nlp):
         # spacy tokens -> text char
         'offset_mapping': tokenized_texts['offset_mapping']
     }
+
+
+def preprocess_tokenized_texts(tokenized_texts):
+    final_tokenized_texts = {'tokens': tokenized_texts, "offset_mapping": []}
+    for i, tokenized_text in enumerate(tokenized_texts):
+        final_tokenized_texts["offset_mapping"].append([])
+        start = 0
+        for tok in tokenized_text:
+            final_tokenized_texts["offset_mapping"][i].append((start, start + len(tok)))
+            start += len(tok) + 1
+    return final_tokenized_texts
 
 
 def tokenize_with_spacy(texts, nlp):

--- a/fastcoref/utilities/util.py
+++ b/fastcoref/utilities/util.py
@@ -84,7 +84,7 @@ def update_metrics(metrics, span_starts, span_ends, gold_clusters, predicted_clu
 
 
 def encode(batch, tokenizer, nlp):
-    if batch['tokenized_text']:
+    if len(batch['tokenized_text']) > 0 and batch['tokenized_text'][0] is not None:
         tokenized_texts = preprocess_tokenized_texts(batch['tokenized_text'])
     else:
         tokenized_texts = tokenize_with_spacy(batch['text'], nlp)


### PR DESCRIPTION
adding an option to call `predict` with a tokenized input (requires passing `None` to `texts`
```python
model.predict(texts=None, tokenized_texts=pretokenized_texts)
```
adding two corresponding methods to `CorefResult`:
- get_clusters_tokenized: which returns the indices of the tokens (not characters)
- get_logit_tokenized: which accepts the spans returned by the get_clusters_tokenized method


 