### PR TITLE
Feature/allow tokenized texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ preds[0].get_logit(
 > 18.852894
 ```
 
+if your text is already tokenized use `is_split_into_words=True`
+```python
+preds = model.predict(
+   texts = [["We", "are", "so", "happy", "to", "see", "you", "using", "our", "coref", 
+             "package", ".", "This", "package", "is", "very", "fast", "!"]],
+   is_split_into_words=True
+)
+```
+
 Processing can be applied to a collection of texts of any length in a batched and parallel fashion:
 
 ```python

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -149,7 +149,7 @@ class CorefModel(ABC):
 
         return dataloader
 
-    def _inference(self, dataloader):
+    def _inference(self, dataloader, is_split_into_words):
         self.model.eval()
         logger.info(f"***** Running Inference on {len(dataloader.dataset)} texts *****")
 
@@ -237,7 +237,7 @@ class CorefModel(ABC):
         dataset = self._create_dataset(texts, is_split_into_words)
         dataloader = self._prepare_batches(dataset, max_tokens_in_batch)
 
-        preds = self._inference(dataloader=dataloader)
+        preds = self._inference(dataloader, is_split_into_words)
         if output_file is not None:
             with open(output_file, 'w') as f:
                 data = [{'text': p.text,

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -193,7 +193,7 @@ class CorefModel(ABC):
                 max_tokens_in_batch: int = 10000,
                 output_file: str = None):
         """
-        text (str, List[str], List[List[str]]) — The sequence or batch of sequences to be encoded.
+        texts (str, List[str], List[List[str]]) — The sequence or batch of sequences to be encoded.
         Each sequence can be a string or a list of strings (pretokenized string).
         If the sequences are provided as list of strings (pretokenized), you must set is_split_into_words=True
         (to lift the ambiguity with a batch of sequences).

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -156,7 +156,7 @@ class CorefModel(ABC):
         results = []
         with tqdm(desc="Inference", total=len(dataloader.dataset)) as progress_bar:
             for batch in dataloader:
-                texts_or_tokens = batch['text']
+                texts = batch['text']
                 subtoken_map = batch['subtoken_map']
                 token_to_char = batch['offset_mapping']
                 idxs = batch['idx']
@@ -168,7 +168,7 @@ class CorefModel(ABC):
                 span_starts, span_ends, mention_logits, coref_logits = outputs_np
                 doc_indices, mention_to_antecedent = create_mention_to_antecedent(span_starts, span_ends, coref_logits)
 
-                for i in range(len(texts_or_tokens)):
+                for i in range(len(texts)):
                     doc_mention_to_antecedent = mention_to_antecedent[np.nonzero(doc_indices == i)]
                     predicted_clusters = create_clusters(doc_mention_to_antecedent)
 
@@ -177,13 +177,13 @@ class CorefModel(ABC):
                     )
 
                     res = CorefResult(
-                        text=texts_or_tokens[i], clusters=predicted_clusters,
+                        text=texts[i], clusters=predicted_clusters,
                         char_map=char_map, reverse_char_map=reverse_char_map,
                         coref_logit=coref_logits[i], text_idx=idxs[i]
                     )
                     results.append(res)
 
-                progress_bar.update(n=len(texts_or_tokens))
+                progress_bar.update(n=len(texts))
 
         return sorted(results, key=lambda res: res.text_idx)
 

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -149,7 +149,7 @@ class CorefModel(ABC):
 
         return dataloader
 
-    def _inference(self, dataloader, is_split_into_words):
+    def _inference(self, dataloader):
         self.model.eval()
         logger.info(f"***** Running Inference on {len(dataloader.dataset)} texts *****")
 
@@ -238,7 +238,7 @@ class CorefModel(ABC):
         dataset = self._create_dataset(texts, is_split_into_words)
         dataloader = self._prepare_batches(dataset, max_tokens_in_batch)
 
-        preds = self._inference(dataloader, is_split_into_words)
+        preds = self._inference(dataloader)
         if output_file is not None:
             with open(output_file, 'w') as f:
                 data = [{'text': p.text,

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -223,7 +223,7 @@ class CorefModel(ABC):
 
         if not _is_valid_text_input(texts):
             raise ValueError(
-                "text input must of type `str` (single example), `List[str]` (batch or single pretokenized example) "
+                "text input must be of type `str` (single example), `List[str]` (batch or single pretokenized example) "
                 "or `List[List[str]]` (batch of pretokenized examples)."
             )
 

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -201,27 +201,27 @@ class CorefModel(ABC):
         """
 
         # Input type checking for clearer error
-        def _is_valid_text_input(t):
-            if isinstance(t, str):
+        def _is_valid_text_input(texts, is_split_into_words):
+            if isinstance(texts, str) and not is_split_into_words:
                 # Strings are fine
                 return True
-            elif isinstance(t, (list, tuple)):
+            elif isinstance(texts, (list, tuple)):
                 # List are fine as long as they are...
-                if len(t) == 0:
+                if len(texts) == 0:
                     # ... empty
                     return True
-                elif isinstance(t[0], str):
+                elif all([isinstance(t, str) for t in texts]):
                     # ... list of strings
                     return True
-                elif isinstance(t[0], (list, tuple)):
+                elif all([isinstance(t, (list, tuple)) for t in texts]):
                     # ... list with an empty list or with a list of strings
-                    return len(t[0]) == 0 or isinstance(t[0][0], str)
+                    return len(texts[0]) == 0 or isinstance(texts[0][0], str)
                 else:
                     return False
             else:
                 return False
 
-        if not _is_valid_text_input(texts):
+        if not _is_valid_text_input(texts, is_split_into_words):
             raise ValueError(
                 "text input must be of type `str` (single example), `List[str]` (batch or single pretokenized example) "
                 "or `List[List[str]]` (batch of pretokenized examples)."

--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -197,6 +197,7 @@ class CorefModel(ABC):
         Each sequence can be a string or a list of strings (pretokenized string).
         If the sequences are provided as list of strings (pretokenized), you must set is_split_into_words=True
         (to lift the ambiguity with a batch of sequences).
+        is_split_into_words - indicate if the texts input is tokenized
         """
 
         # Input type checking for clearer error

--- a/fastcoref/utilities/util.py
+++ b/fastcoref/utilities/util.py
@@ -88,7 +88,8 @@ def encode(batch, tokenizer, nlp):
         tokenized_texts = tokenize_with_spacy(batch['text'], nlp)
     else:
         tokenized_texts = batch
-        tokenized_texts['offset_mapping'] = [[None] * len(tokens) for tokens in tokenized_texts['tokens']]
+        tokenized_texts['offset_mapping'] = [(list(zip(range(len(tokens)), range(1, 1 + len(tokens)))))
+                                             for tokens in tokenized_texts['tokens']]
     encoded_batch = tokenizer(
         tokenized_texts['tokens'], add_special_tokens=True, is_split_into_words=True,
         return_length=True, return_attention_mask=False

--- a/fastcoref/utilities/util.py
+++ b/fastcoref/utilities/util.py
@@ -84,7 +84,11 @@ def update_metrics(metrics, span_starts, span_ends, gold_clusters, predicted_clu
 
 
 def encode(batch, tokenizer, nlp):
-    tokenized_texts = tokenize_with_spacy(batch['text'], nlp)
+    if nlp is not None:
+        tokenized_texts = tokenize_with_spacy(batch['text'], nlp)
+    else:
+        tokenized_texts = batch
+        tokenized_texts['offset_mapping'] = [[None] * len(tokens) for tokens in tokenized_texts['tokens']]
     encoded_batch = tokenizer(
         tokenized_texts['tokens'], add_special_tokens=True, is_split_into_words=True,
         return_length=True, return_attention_mask=False

--- a/tests/local_test.py
+++ b/tests/local_test.py
@@ -6,9 +6,10 @@ texts = ['We are so happy to see you using our coref package. This package is ve
 
 model = FCoref(device='cpu')
 
-preds = model.predict(texts=texts, max_tokens_in_batch=5000, output_file='out_test.jsonlines')
+preds = model.predict(texts=texts[0], max_tokens_in_batch=5000, output_file='out_test.jsonlines')
+print(preds)
 
-preds = model.predict(texts=texts, max_tokens_in_batch=5000)
+preds = model.predict(texts=texts, max_tokens_in_batch=5000, output_file='out_test.jsonlines')
 print(preds)
 
 for p in preds:

--- a/tests/test_tokenized_text.py
+++ b/tests/test_tokenized_text.py
@@ -1,0 +1,25 @@
+from fastcoref import FCoref, LingMessCoref
+import spacy
+
+texts = ['We are so happy to see you using our coref package. This package is very fast!',
+         'The man tried to put the boot on his foot but it was too small.',
+         "I have a dog. The dog's toys are really cool."]
+
+model = FCoref(device='cpu')
+preds = model.predict(texts=texts)
+for p in preds:
+    print(p.get_clusters())
+
+
+texts = [["We", "are", "so", "happy", "to", "see", "you", "using", "our", "coref", "package", ".", "This", "package", "is", "very", "fast", "!"],
+["The", "man", "tried", "to", "put", "the", "boot", "on", "his", "foot", "but", "it", "was", "too", "small", "."],
+["I", "have", "a", "dog", ".", "The", "dog", "\'s", "toys", "are", "really", "cool", "."]]
+
+model = FCoref(device='cpu')
+preds = model.predict(texts, is_split_into_words=True)
+for p in preds:
+    print(p.get_clusters())
+
+model = FCoref(device='cpu')
+preds = model.predict(texts[0], is_split_into_words=True)
+print(preds)

--- a/tests/test_tokenized_text.py
+++ b/tests/test_tokenized_text.py
@@ -1,25 +1,31 @@
 from fastcoref import FCoref, LingMessCoref
 import spacy
 
+model = FCoref(device='cpu')
+
 texts = ['We are so happy to see you using our coref package. This package is very fast!',
          'The man tried to put the boot on his foot but it was too small.',
          "I have a dog. The dog's toys are really cool."]
 
-model = FCoref(device='cpu')
 preds = model.predict(texts=texts)
 for p in preds:
     print(p.get_clusters())
 
+preds = model.predict(texts[0])
+print(preds)
 
 texts = [["We", "are", "so", "happy", "to", "see", "you", "using", "our", "coref", "package", ".", "This", "package", "is", "very", "fast", "!"],
 ["The", "man", "tried", "to", "put", "the", "boot", "on", "his", "foot", "but", "it", "was", "too", "small", "."],
 ["I", "have", "a", "dog", ".", "The", "dog", "\'s", "toys", "are", "really", "cool", "."]]
 
-model = FCoref(device='cpu')
 preds = model.predict(texts, is_split_into_words=True)
 for p in preds:
     print(p.get_clusters())
 
-model = FCoref(device='cpu')
 preds = model.predict(texts[0], is_split_into_words=True)
+print(preds)
+
+texts = ["cant fool you", ["or", "can", "I", "?"]]
+model = FCoref(device='cpu')
+preds = model.predict(texts, is_split_into_words=False)
 print(preds)


### PR DESCRIPTION
predict function now accept this inputs:
`texts (str, List[str], List[List[str]])` — The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings (pretokenized string).If the sequences are provided as list of strings (pretokenized), you must set is_split_into_words=True (to lift the ambiguity with a batch of sequences)
`is_split_into_words` - indicate if the texts input is tokenized


Usage:

```python
texts = [["We", "are", "so", "happy", "to", "see", "you", "using", "our", "coref", "package", ".", "This", "package", "is", "very", "fast", "!"],
["The", "man", "tried", "to", "put", "the", "boot", "on", "his", "foot", "but", "it", "was", "too", "small", "."],
["I", "have", "a", "dog", ".", "The", "dog", "\'s", "toys", "are", "really", "cool", "."]]

model = FCoref(device='cpu')
preds = model.predict(texts, is_split_into_words=True)
for p in preds:
    print(p.get_clusters())
>
[[['We'], ['our']], [['our', 'coref', 'package'], ['This', 'package']]]
[[['The', 'man'], ['his']], [['his', 'foot'], ['it']]]
[[['a', 'dog'], ['The', 'dog', "'s"]]]
```

Note: no changes to `CorefResult`. solved with:
```python
    if nlp is not None:
        tokenized_texts = tokenize_with_spacy(batch['text'], nlp)
    else:
        tokenized_texts = batch
        tokenized_texts['offset_mapping'] = [(list(zip(range(len(tokens)), range(1, 1 + len(tokens)))))
                                             for tokens in tokenized_texts['tokens']]
```