### PR TITLE
feat: Disable progress bar logging at inference time.

### DIFF
--- a/fastcoref/modeling.py
+++ b/fastcoref/modeling.py
@@ -66,11 +66,12 @@ class CorefResult:
 
 
 class CorefModel(ABC):
-    def __init__(self, model_name_or_path, coref_class, collator_class, device=None, nlp=None):
+    def __init__(self, model_name_or_path, coref_class, collator_class, enable_progress_bar, device=None, nlp=None):
         self.model_name_or_path = model_name_or_path
         self.device = device
         self.seed = 42
         self._set_device()
+        self.enable_progress_bar = enable_progress_bar
 
         config = AutoConfig.from_pretrained(self.model_name_or_path)
         self.max_segment_len = config.coref_head['max_segment_len']
@@ -149,41 +150,48 @@ class CorefModel(ABC):
 
         return dataloader
 
+    def _batch_inference(self, batch):
+        texts = batch['text']
+        subtoken_map = batch['subtoken_map']
+        token_to_char = batch['offset_mapping']
+        idxs = batch['idx']
+        with torch.no_grad():
+            outputs = self.model(batch, return_all_outputs=True)
+
+        outputs_np = tuple(tensor.cpu().numpy() for tensor in outputs)
+
+        span_starts, span_ends, mention_logits, coref_logits = outputs_np
+        doc_indices, mention_to_antecedent = create_mention_to_antecedent(span_starts, span_ends, coref_logits)
+
+        for i in range(len(texts)):
+            doc_mention_to_antecedent = mention_to_antecedent[np.nonzero(doc_indices == i)]
+            predicted_clusters = create_clusters(doc_mention_to_antecedent)
+
+            char_map, reverse_char_map = align_to_char_level(
+                span_starts[i], span_ends[i], token_to_char[i], subtoken_map[i]
+            )
+
+            res = CorefResult(
+                text=texts[i], clusters=predicted_clusters,
+                char_map=char_map, reverse_char_map=reverse_char_map,
+                coref_logit=coref_logits[i], text_idx=idxs[i]
+            )
+
+            return res
+
     def _inference(self, dataloader):
         self.model.eval()
         logger.info(f"***** Running Inference on {len(dataloader.dataset)} texts *****")
 
         results = []
-        with tqdm(desc="Inference", total=len(dataloader.dataset)) as progress_bar:
+        if self.enable_progress_bar:
+            with tqdm(desc="Inference", total=len(dataloader.dataset)) as progress_bar:
+                for batch in dataloader:
+                    results.append(self._batch_inference(batch))
+                    progress_bar.update(n=len(batch['texts']))
+        else:
             for batch in dataloader:
-                texts = batch['text']
-                subtoken_map = batch['subtoken_map']
-                token_to_char = batch['offset_mapping']
-                idxs = batch['idx']
-                with torch.no_grad():
-                    outputs = self.model(batch, return_all_outputs=True)
-
-                outputs_np = tuple(tensor.cpu().numpy() for tensor in outputs)
-
-                span_starts, span_ends, mention_logits, coref_logits = outputs_np
-                doc_indices, mention_to_antecedent = create_mention_to_antecedent(span_starts, span_ends, coref_logits)
-
-                for i in range(len(texts)):
-                    doc_mention_to_antecedent = mention_to_antecedent[np.nonzero(doc_indices == i)]
-                    predicted_clusters = create_clusters(doc_mention_to_antecedent)
-
-                    char_map, reverse_char_map = align_to_char_level(
-                        span_starts[i], span_ends[i], token_to_char[i], subtoken_map[i]
-                    )
-
-                    res = CorefResult(
-                        text=texts[i], clusters=predicted_clusters,
-                        char_map=char_map, reverse_char_map=reverse_char_map,
-                        coref_logit=coref_logits[i], text_idx=idxs[i]
-                    )
-                    results.append(res)
-
-                progress_bar.update(n=len(texts))
+                results.append(self._batch_inference(batch))
 
         return sorted(results, key=lambda res: res.text_idx)
 
@@ -252,14 +260,10 @@ class CorefModel(ABC):
 
 
 class FCoref(CorefModel):
-    def __init__(self, model_name_or_path='biu-nlp/f-coref', device=None, nlp=None):
-        super().__init__(model_name_or_path, FCorefModel, LeftOversCollator, device, nlp)
+    def __init__(self, model_name_or_path='biu-nlp/f-coref', device=None, nlp=None, enable_progress_bar=True):
+        super().__init__(model_name_or_path, FCorefModel, LeftOversCollator, enable_progress_bar, device, nlp)
 
 
 class LingMessCoref(CorefModel):
-    def __init__(self, model_name_or_path='biu-nlp/lingmess-coref', device=None, nlp=None):
-        super().__init__(model_name_or_path, LingMessModel, PadCollator, device, nlp)
-
-
-
-
+    def __init__(self, model_name_or_path='biu-nlp/lingmess-coref', device=None, nlp=None, enable_progress_bar=True):
+        super().__init__(model_name_or_path, LingMessModel, PadCollator, enable_progress_bar, device, nlp)

--- a/fastcoref/spacy_component/spacy_component.py
+++ b/fastcoref/spacy_component/spacy_component.py
@@ -1,44 +1,45 @@
-
 from spacy import Language, util
 from spacy.tokens import Doc, Span
 from fastcoref import FCoref, LingMessCoref
-from typing import List,Tuple
+from typing import List, Tuple
 
 
 @Language.factory(
     "fastcoref",
-    assigns=["doc._.resolved_text","doc._.coref_clusters"],
+    assigns=["doc._.resolved_text", "doc._.coref_clusters"],
     default_config={
-        "model_architecture": 'FCoref', # FCoref or LingMessCoref 
-        "model_path": 'biu-nlp/f-coref', # You can specify your own trained model path
-        "device": None, # "cuda" or "cpu" None defaults to cuda
-        "max_tokens_in_batch":10000
+        "model_architecture": 'FCoref',  # FCoref or LingMessCoref
+        "model_path": 'biu-nlp/f-coref',  # You can specify your own trained model path
+        "device": None,  # "cuda" or "cpu" None defaults to cuda
+        "max_tokens_in_batch": 10000,
+        "enable_progress_bar": True
     },
 )
 class FastCorefResolver:
     """a class that implements the logic from
     https://towardsdatascience.com/how-to-make-an-effective-coreference-resolution-model-55875d2b5f19"""
     def __init__(
-        self,
-        nlp,
-        name,
-        model_architecture: str,
-        model_path: str,
-        device,
-        max_tokens_in_batch: int
+            self,
+            nlp,
+            name,
+            model_architecture: str,
+            model_path: str,
+            device,
+            max_tokens_in_batch: int,
+            enable_progress_bar,
     ):
-        assert model_architecture in ["FCoref","LingMessCoref"]
-        if model_architecture == "FCoref": 
-            self.coref_model = FCoref(model_name_or_path = model_path, device=device, nlp=nlp)
+        assert model_architecture in ["FCoref", "LingMessCoref"]
+        if model_architecture == "FCoref":
+            self.coref_model = FCoref(model_name_or_path=model_path, device=device, nlp=nlp, enable_progress_bar=enable_progress_bar)
         elif model_architecture == "LingMessCoref":
-            self.coref_model = LingMessCoref(model_name_or_path = model_path, device=device, nlp=nlp)
+            self.coref_model = LingMessCoref(model_name_or_path=model_path, device=device, nlp=nlp, enable_progress_bar=enable_progress_bar)
         self.max_tokens_in_batch = max_tokens_in_batch
         # Register custom extension on the Doc
         if not Doc.has_extension("resolved_text"):
             Doc.set_extension("resolved_text", default="")
         if not Doc.has_extension("coref_clusters"):
             Doc.set_extension("coref_clusters", default=None)
-         
+
     def _get_span_noun_indices(self, doc: Doc, cluster: List[Tuple]) -> List[int]:
         """
         > Get the indices of the spans in the cluster that contain at least one noun or proper noun
@@ -52,6 +53,7 @@ class FastCorefResolver:
             i for i, span_pos in enumerate(spans_pos) if any(pos in span_pos for pos in ["NOUN", "PROPN"])
         ]
         return span_noun_indices
+
     def _get_cluster_head(self, doc: Doc, cluster: List[Tuple], noun_indices: List[int]):
         """
         > Given a spaCy Doc, a coreference cluster, and a list of noun indices, return the head span and its start and end
@@ -68,6 +70,7 @@ class FastCorefResolver:
         head_start,head_end = cluster[head_idx]
         head_span = doc.char_span(head_start,head_end)
         return head_span, [head_start, head_end]
+
     def _is_containing_other_spans(self,span: List[int], all_spans: List[List[int]]):
         """
         It returns True if there is any span in all_spans that is contained within span and is not equal to span
@@ -78,6 +81,7 @@ class FastCorefResolver:
         :return: A list of all spans that are not contained in any other span.
         """
         return any([s[0] >= span[0] and s[1] <= span[1] and s != span for s in all_spans])
+
     def _core_logic_part(self,document: Doc, coref: List[int], resolved: List[str], mention_span: Span):
         """
         If the last token of the mention is a possessive pronoun, then add an apostrophe and an s to the mention.


### PR DESCRIPTION
* Add a progress bar flag in the CorefModel constructor. 
* Add a default value in the Spacy configuration.
* Add the constructor argument with default value set to True in subclasses. 
* Move the core of _inference to a separate method to avoid duplicate code. 
* Display the progress bar in _inference only if the progress bar flag is set.


See https://github.com/shon-otmazgin/fastcoref/issues/16