### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The `fastcoref` Python package provides an easy and fast API for coreference inf
 
 ## Installation
 
+Note: Requires python **>=3.6,<3.9**!
+
 ```bash
 pip install fastcoref
 # or for training:


### PR DESCRIPTION
The dependency `neuralcoref` requires python <3.9 and installation of this library fails for python >=3.9. This is probably because of https://github.com/numpy/numpy/issues/17937.

This updates the docs to indicate that. Later work would perhaps want to add this stringency to `setup.py`.