### PR TITLE
modernize, fix: compatibility with transformers>=4.46

### DIFF
--- a/fastcoref/coref_models/modeling_fcoref.py
+++ b/fastcoref/coref_models/modeling_fcoref.py
@@ -31,6 +31,8 @@ class FullyConnectedLayer(Module):
 
 
 class FCorefModel(BertPreTrainedModel):
+    all_tied_weights_keys: dict = {}
+
     def __init__(self, config):
         super().__init__(config)
         self.max_span_length = config.coref_head['max_span_length']
@@ -38,7 +40,7 @@ class FCorefModel(BertPreTrainedModel):
         self.ffnn_size = config.coref_head['ffnn_size']
         self.dropout_prob = config.coref_head['dropout_prob']
 
-        base_model = AutoModel.from_config(config)
+        base_model = AutoModel.from_config(config, attn_implementation="eager")
         FCorefModel.base_model_prefix = base_model.base_model_prefix
         FCorefModel.config_class = base_model.config_class
         setattr(self, self.base_model_prefix, base_model)

--- a/fastcoref/coref_models/modeling_lingmess.py
+++ b/fastcoref/coref_models/modeling_lingmess.py
@@ -33,6 +33,8 @@ class FullyConnectedLayer(Module):
 
 
 class LingMessModel(BertPreTrainedModel):
+    all_tied_weights_keys: dict = {}
+
     def __init__(self, config):
         super().__init__(config)
         self.max_span_length = config.coref_head['max_span_length']
@@ -45,7 +47,7 @@ class LingMessModel(BertPreTrainedModel):
         self.all_cats_size = self.ffnn_size * self.num_cats
 
         # this is how huggingface loading the class model and setting the name of the variable.
-        base_model = AutoModel.from_config(config)
+        base_model = AutoModel.from_config(config, attn_implementation="eager")
         LingMessModel.base_model_prefix = base_model.base_model_prefix
         LingMessModel.config_class = base_model.config_class
         setattr(self, self.base_model_prefix, base_model)


### PR DESCRIPTION
* Modernized the repo, specially dependencies
* Fixed a bug regarding modern transformers, should unblock  
All tests passed.

```python
uv run pytest
=============================================================== test session starts ===============================================================
platform linux -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/masterkenway/Projects/fastcoref
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.13.0
collected 12 items                                                                                                                                

tests/test_fcoref.py ......                                                                                                                 [ 50%]
tests/test_lingmess_coref.py ......                                                                                                         [100%]

================================================================ warnings summary =================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 12 passed, 2 warnings in 58.81s =========================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```